### PR TITLE
bugfix: Enable input _echo-##_ tags to be read regardless of zero padding use…

### DIFF
--- a/utils/read_bids_to_filelist.m
+++ b/utils/read_bids_to_filelist.m
@@ -175,8 +175,9 @@ img = [];
 while numFileLoaded ~= NumFiles
     
     for k = 1:NumFiles
-        
-        if ContainName(fileList(k).name, ['echo-' num2str(numFileLoaded+1) '_']) || ContainName(fileList(k).name, ['echo-' num2str(numFileLoaded+1) '.'])
+        # PSF: Fix to enable numbering of echoes with arbitrary zero padding, i.e. 01,02 etc.
+        echoNumber = str2double(cell2mat(regexp(fileList(k).name,'echo-(\d*)','tokens','once')));
+        if echoNumber == numFileLoaded+1
             nii = load_untouch_nii(fileList(k).name);
             
             if (abs(max(nii.img(:))-pi)>1e-4 || abs(min(nii.img(:))-(-pi))>1e-4) && isPhase % allow small differences possibly due to data stype conversion

--- a/utils/read_bids_to_filelist.m
+++ b/utils/read_bids_to_filelist.m
@@ -175,7 +175,7 @@ img = [];
 while numFileLoaded ~= NumFiles
     
     for k = 1:NumFiles
-        # PSF: Fix to enable numbering of echoes with arbitrary zero padding, i.e. 01,02 etc.
+        % 20250702: bug fix to enable numbering of echoes with arbitrary zero padding, i.e. 01,02 etc.
         echoNumber = str2double(cell2mat(regexp(fileList(k).name,'echo-(\d*)','tokens','once')));
         if echoNumber == numFileLoaded+1
             nii = load_untouch_nii(fileList(k).name);


### PR DESCRIPTION
…d in echo number

The original code only matched if the echoes were numbered 1,2,3,4 and would hang in an indefinite loop if these were not found, which is the case for datasets with echoes numbered as 01,02,03,04.

Code now simply matches the echo number, and converts into double, which can then be compared to the actual number used in the loop.