### PR TITLE
Remove verbose terminal output

### DIFF
--- a/wrapper/BackgroundRemovalMacro.m
+++ b/wrapper/BackgroundRemovalMacro.m
@@ -44,12 +44,7 @@ refine_order        = algorParam.bfr.refine_order;
 
 headerAndExtraData = check_and_set_SEPIA_header_data(headerAndExtraData);
 
-disp('-----------------------------');
-disp('Background field removal step');
-disp('-----------------------------');
-
 %% zero padding for odd number dimension
-fprintf('Zero-padding data if the input images have odd number matrix size...');
 totalField  = double(zeropad_odd_dimension(totalField,'pre'));
 mask        = double(zeropad_odd_dimension(mask,'pre'));
 % additional input
@@ -60,8 +55,6 @@ if ~isempty(headerAndExtraData.phase)
     headerAndExtraData.phase = double(zeropad_odd_dimension(headerAndExtraData.phase,'pre'));
 end
 matrixSize_new = size(totalField);
-
-fprintf('Done!\n');
 
 %% erode mask before BFR
 if erode_before_radius > 0
@@ -80,15 +73,11 @@ if erode_before_radius > 0
 end
 
 %% core of background field removal
-disp('Removing background field...');
-disp(['The following method is being used: ' method]);
-
 for k = 1:length(wrapper_BFR_function)
     if strcmpi(method,methodBFRName{k})
         RDF = feval(wrapper_BFR_function{k},totalField,mask,matrixSize_new,voxelSize,algorParam,headerAndExtraData);
     end
 end
-disp('Done!');
 
 maskLocalFiled = RDF ~=0;
 

--- a/wrapper/UnwrapPhaseMacro.m
+++ b/wrapper/UnwrapPhaseMacro.m
@@ -37,10 +37,6 @@ method              = algorParam.unwrap.unwrapMethod;
 
 headerAndExtraData = check_and_set_SEPIA_header_data(headerAndExtraData);
 
-disp('------------------------');
-disp('Spatial phase unwrapping');
-disp('------------------------');
-
 % give a warning if no mask is provided
 if isempty(mask)
     mask = ones(matrixSize);
@@ -55,7 +51,6 @@ end
 %% Laplacian based method required prior zero padding for odd number dimension
 % use same data type (20190529: single-precision can affect the result of
 % some methods)
-fprintf('Zero-padding data if the input images have odd number matrix size...');
 if strcmpi(method,methodUnwrapName{1}) || strcmpi(method,methodUnwrapName{2})
     wrappedField    = double(zeropad_odd_dimension(wrappedField,'pre'));
     mask            = double(zeropad_odd_dimension(mask,'pre'));
@@ -66,12 +61,7 @@ if strcmpi(method,methodUnwrapName{1}) || strcmpi(method,methodUnwrapName{2})
 end
 matrixSize_new = size(wrappedField);
 
-fprintf('Done!\n');
-
 %% phase unwrapping
-disp('Unwrapping phase image...');
-disp(['The following method is being used: ' method]);
-
 for k = 1:length(wrapper_Unwrap_function)
     if strcmpi(method,methodUnwrapName{k})
         try 
@@ -83,7 +73,6 @@ for k = 1:length(wrapper_Unwrap_function)
         end
     end
 end
-disp('Done!');
 
 %% remove zero padding with Laplacian based method result
 if strcmpi(method,methodUnwrapName{1}) || strcmpi(method,methodUnwrapName{2})


### PR DESCRIPTION
Sepia is producing pages and pages of the same information, which makes it difficult to scroll through the logs. This PR removes some unimportant/over-verbose terminal prints. If you still like to print the info, can you please do it only once